### PR TITLE
Add Taylor Swift Eras analysis feature and improve ESPN API support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,4 @@ jobs:
 
     - name: Run mypy type checking
       run: |
-        mypy src/gmb --ignore-missing-imports
+        mypy src/gmb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install ruff mypy
+        pip install ruff mypy types-requests types-PyYAML
 
     - name: Run ruff format check
       run: |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A dashboard for tracking ESPN fantasy football leagues with advanced statistics 
   - **Analytics**: Weekly scoring trends and points analysis
   - **Power Rankings**: Weighted team performance metrics
   - **OIWP Analysis**: Opponent-Independent Winning Percentage with luck factor
+  - **Taylor Eras**: Historical win percentage analysis by Taylor Swift album eras
 - **Command-Line Tools**:
   - `gmb setup`: Interactive configuration
   - `gmb summary`: Display league standings
@@ -63,7 +64,7 @@ Launch the interactive Streamlit dashboard:
 streamlit run app.py
 ```
 
-The dashboard includes four main tabs:
+The dashboard includes five main tabs:
 
 1. **📊 Overview**: League standings and summary metrics
 2. **📈 Analytics**: Weekly scoring trends and points comparisons
@@ -73,6 +74,10 @@ The dashboard includes four main tabs:
    - Shows how teams would perform against all opponents
    - Identifies "lucky" teams (winning despite lower scores)
    - Identifies "unlucky" teams (losing despite higher scores)
+5. **🎵 Taylor Eras**: Historical performance by Taylor Swift album release eras
+   - Win percentage heatmap across different eras
+   - Game-by-game era assignment based on actual dates
+   - Identifies most dominant owner-era combinations
 
 ### Command-Line Interface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ python_version = "3.13"
 warn_unused_configs = true
 check_untyped_defs = true
 ignore_missing_imports = true
+strict = true
+warn_return_any = true
 
 # Per-module options for external libraries
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,8 +96,11 @@ indent-style = "space"
 
 [tool.mypy]
 python_version = "3.13"
-strict = false
-warn_return_any = false
 warn_unused_configs = true
 check_untyped_defs = true
-disallow_untyped_decorators = false
+ignore_missing_imports = true
+
+# Per-module options for external libraries
+[[tool.mypy.overrides]]
+module = "typer.*"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dev = [
     "ruff>=0.1.0",
     "isort>=5.12.0",
     "mypy>=1.5.0",
+    "types-requests>=2.31.0",
+    "types-PyYAML>=6.0.0",
 ]
 
 [project.scripts]
@@ -94,7 +96,8 @@ indent-style = "space"
 
 [tool.mypy]
 python_version = "3.13"
-strict = true
-warn_return_any = true
+strict = false
+warn_return_any = false
 warn_unused_configs = true
 check_untyped_defs = true
+disallow_untyped_decorators = false

--- a/src/gmb/espn.py
+++ b/src/gmb/espn.py
@@ -31,7 +31,13 @@ class ESPNFantasyLeague:
         """
         self.league_id = league_id
         self.year = year
-        self.base_url = f"https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/seasons/{year}/segments/0/leagues/{league_id}"
+
+        # ESPN changed their API structure around 2018
+        if year < 2018:
+            self.base_url = f"https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/leagueHistory/{league_id}?seasonId={year}"
+        else:
+            self.base_url = f"https://lm-api-reads.fantasy.espn.com/apis/v3/games/ffl/seasons/{year}/segments/0/leagues/{league_id}"
+
         self.cookies = {}
         if espn_s2 and swid:
             self.cookies = {"espn_s2": espn_s2, "SWID": swid}  # Note: SWID must be uppercase
@@ -87,7 +93,9 @@ class ESPNFantasyLeague:
             ValueError: If ESPN API access is denied (403)
             requests.HTTPError: For other HTTP errors
         """
-        url = f"{self.base_url}?view=mTeam"
+        # For pre-2018, base_url already has query params, so use & instead of ?
+        separator = "&" if self.year < 2018 else "?"
+        url = f"{self.base_url}{separator}view=mTeam"
         response = requests.get(url, cookies=self.cookies, timeout=REQUEST_TIMEOUT)
 
         if response.status_code == 403:
@@ -102,13 +110,29 @@ class ESPNFantasyLeague:
 
         data = response.json()
 
+        # For pre-2018, the API returns an array with one league object
+        if self.year < 2018 and isinstance(data, list):
+            data = data[0] if data else {}
+
+        # Create owner ID to name mapping
+        owner_map = {}
+        for member in data.get("members", []):
+            owner_id = member.get("id")
+            first_name = member.get("firstName", "")
+            last_name = member.get("lastName", "")
+            # Normalize to title case to handle inconsistent capitalization across years
+            owner_map[owner_id] = f"{first_name} {last_name}".strip().title()
+
         teams_data: list[dict[str, Any]] = []
         for team in data["teams"]:
+            owner_id = team["primaryOwner"]
+            owner_name = owner_map.get(owner_id, owner_id)  # Fall back to ID if name not found
+
             teams_data.append(
                 {
                     "team_id": team["id"],
                     "team_name": team["name"],
-                    "owner": team["primaryOwner"],
+                    "owner": owner_name,
                     "wins": team["record"]["overall"]["wins"],
                     "losses": team["record"]["overall"]["losses"],
                     "points_for": team["record"]["overall"]["pointsFor"],
@@ -124,11 +148,17 @@ class ESPNFantasyLeague:
         Returns:
             Current week number (defaults to 1 if not found)
         """
-        url = f"{self.base_url}?view=mSettings"
+        separator = "&" if self.year < 2018 else "?"
+        url = f"{self.base_url}{separator}view=mSettings"
         response = requests.get(url, cookies=self.cookies, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
 
         data = response.json()
+
+        # For pre-2018, the API returns an array with one league object
+        if self.year < 2018 and isinstance(data, list):
+            data = data[0] if data else {}
+
         scoring_period: int = data.get("scoringPeriodId", 1)
         return scoring_period
 
@@ -161,13 +191,19 @@ class ESPNFantasyLeague:
 
         all_matchups = []
         for w in weeks_to_fetch:
-            url = f"{self.base_url}?view=mMatchup&scoringPeriodId={w}"
+            separator = "&" if self.year < 2018 else "?"
+            url = f"{self.base_url}{separator}view=mMatchup&scoringPeriodId={w}"
             response = requests.get(url, cookies=self.cookies, timeout=REQUEST_TIMEOUT)
 
             if response.status_code != 200:
                 continue  # Skip weeks that fail
 
             data = response.json()
+
+            # For pre-2018, the API returns an array with one league object
+            if self.year < 2018 and isinstance(data, list):
+                data = data[0] if data else {}
+
             week_matchups = self._extract_matchups(data, w)
 
             # Only include weeks with actual scores (filter out future/unplayed weeks)

--- a/src/gmb/taylor_eras.py
+++ b/src/gmb/taylor_eras.py
@@ -1,0 +1,242 @@
+"""Taylor Swift Eras analysis for fantasy football."""
+
+from datetime import datetime, timedelta
+from typing import Any, TypedDict
+
+import pandas as pd
+
+
+class EraDict(TypedDict):
+    """Type definition for era dictionary."""
+
+    era: str
+    start_date: datetime
+    end_date: datetime
+
+
+# Taylor Swift album release dates
+TAYLOR_ERAS: list[EraDict] = [
+    {
+        "era": "Taylor Swift",
+        "start_date": datetime(2006, 10, 24),
+        "end_date": datetime(2008, 11, 11),
+    },
+    {
+        "era": "Fearless",
+        "start_date": datetime(2008, 11, 11),
+        "end_date": datetime(2010, 10, 25),
+    },
+    {
+        "era": "Speak Now",
+        "start_date": datetime(2010, 10, 25),
+        "end_date": datetime(2012, 10, 22),
+    },
+    {
+        "era": "Red",
+        "start_date": datetime(2012, 10, 22),
+        "end_date": datetime(2014, 10, 27),
+    },
+    {
+        "era": "1989",
+        "start_date": datetime(2014, 10, 27),
+        "end_date": datetime(2017, 11, 10),
+    },
+    {
+        "era": "Reputation",
+        "start_date": datetime(2017, 11, 10),
+        "end_date": datetime(2019, 8, 23),
+    },
+    {
+        "era": "Lover",
+        "start_date": datetime(2019, 8, 23),
+        "end_date": datetime(2020, 7, 24),
+    },
+    {
+        "era": "Folklore",
+        "start_date": datetime(2020, 7, 24),
+        "end_date": datetime(2020, 12, 11),
+    },
+    {
+        "era": "Evermore",
+        "start_date": datetime(2020, 12, 11),
+        "end_date": datetime(2022, 10, 21),
+    },
+    {
+        "era": "Midnights",
+        "start_date": datetime(2022, 10, 21),
+        "end_date": datetime(2024, 4, 19),
+    },
+    {
+        "era": "The Tortured Poets Department",
+        "start_date": datetime(2024, 4, 19),
+        "end_date": datetime(2025, 10, 3),
+    },
+    {
+        "era": "The Life of a Showgirl",
+        "start_date": datetime(2025, 10, 3),
+        "end_date": datetime(2025, 12, 31),  # Current era, end date is placeholder
+    },
+]
+
+
+def get_week_date(year: int, week: int) -> datetime:
+    """Convert a fantasy football week number to an approximate date.
+
+    Args:
+        year: Fantasy football season year
+        week: Week number (1-17 typically)
+
+    Returns:
+        Approximate date for that week
+    """
+    # NFL season typically starts the first Tuesday after Labor Day (first Monday in September)
+    # Week 1 is usually the second week of September
+    # We'll approximate: first game of week N is roughly Sept 1 + (N-1) * 7 days
+    season_start = datetime(year, 9, 1)
+    return season_start + timedelta(days=(week - 1) * 7)
+
+
+def get_era_for_date(date: datetime) -> str:
+    """Get the Taylor Swift era for a specific date.
+
+    Args:
+        date: The date to check
+
+    Returns:
+        The era name for that date
+    """
+    for era in TAYLOR_ERAS:
+        if era["start_date"] <= date < era["end_date"]:
+            return era["era"]
+    return "Unknown Era"
+
+
+def get_era_for_year(year: int) -> str:
+    """Get the Taylor Swift era(s) for a given fantasy football season year.
+
+    DEPRECATED: Use get_era_for_date() with actual game dates instead.
+
+    Args:
+        year: Fantasy football season year
+
+    Returns:
+        String describing the era(s) for that season
+    """
+    # Fantasy football seasons typically run from late August/early September to late December/early January
+    season_start = datetime(year, 8, 1)
+    season_end = datetime(year, 12, 31)
+
+    eras_in_season = []
+    for era in TAYLOR_ERAS:
+        # Check if this era overlaps with the fantasy season
+        if era["start_date"] <= season_end and era["end_date"] >= season_start:
+            eras_in_season.append(era["era"])
+
+    if len(eras_in_season) == 1:
+        return eras_in_season[0]
+    elif len(eras_in_season) > 1:
+        return f"{eras_in_season[0]} / {eras_in_season[-1]}"
+    else:
+        return "Unknown Era"
+
+
+def calculate_era_win_percentages(historical_matchups: list[dict[str, Any]]) -> pd.DataFrame:
+    """Calculate winning percentage by Taylor Swift era for each owner.
+
+    Args:
+        historical_matchups: List of dictionaries with keys:
+            - year: int
+            - week: int
+            - team_name: str
+            - owner: str
+            - points: float
+            - opponent_points: float
+
+    Returns:
+        DataFrame with columns: owner, era, games, wins, losses, win_pct
+    """
+    # Add era information and win/loss to each game
+    for game in historical_matchups:
+        game_date = get_week_date(game["year"], game["week"])
+        game["era"] = get_era_for_date(game_date)
+        game["win"] = 1 if game["points"] > game["opponent_points"] else 0
+        game["loss"] = 1 if game["points"] < game["opponent_points"] else 0
+
+    df = pd.DataFrame(historical_matchups)
+
+    # Group by owner and era to calculate aggregated stats
+    era_stats = df.groupby(["owner", "era"]).agg({"win": "sum", "loss": "sum"}).reset_index()
+
+    # Rename columns for consistency
+    era_stats = era_stats.rename(columns={"win": "wins", "loss": "losses"})
+
+    # Calculate win percentage and games played
+    era_stats["games"] = era_stats["wins"] + era_stats["losses"]
+    era_stats["win_pct"] = era_stats["wins"] / era_stats["games"]
+
+    # Sort by era chronologically (based on order in TAYLOR_ERAS)
+    era_order = [era["era"] for era in TAYLOR_ERAS]
+    era_stats["era_order"] = era_stats["era"].apply(
+        lambda x: era_order.index(x) if x in era_order else 999
+    )
+    era_stats = era_stats.sort_values(["era_order", "owner"]).drop(columns=["era_order"])
+
+    return era_stats[["owner", "era", "games", "wins", "losses", "win_pct"]]
+
+
+def get_historical_matchups_data(
+    league_id: int,
+    start_year: int,
+    end_year: int,
+    espn_s2: str | None = None,
+    swid: str | None = None,
+) -> list[dict[str, Any]]:
+    """Fetch historical matchup data from ESPN for multiple years.
+
+    Args:
+        league_id: ESPN league ID
+        start_year: First year to fetch (inclusive)
+        end_year: Last year to fetch (inclusive)
+        espn_s2: ESPN session cookie (for private leagues)
+        swid: ESPN user ID cookie (for private leagues)
+
+    Returns:
+        List of individual game records across all years
+    """
+    from .espn import ESPNFantasyLeague
+
+    all_matchups = []
+
+    for year in range(start_year, end_year + 1):
+        try:
+            league = ESPNFantasyLeague(
+                league_id=league_id,
+                year=year,
+                espn_s2=espn_s2,
+                swid=swid,
+            )
+
+            # Get teams to map team names to owners
+            teams_df = league.get_teams()
+            team_to_owner = {team["team_name"]: team["owner"] for _, team in teams_df.iterrows()}
+
+            # Get all matchups for this year
+            matchups_df = league.get_matchups()
+
+            for _, matchup in matchups_df.iterrows():
+                all_matchups.append(
+                    {
+                        "year": year,
+                        "week": matchup["week"],
+                        "team_name": matchup["team_name"],
+                        "owner": team_to_owner.get(matchup["team_name"], "Unknown"),
+                        "points": matchup["points"],
+                        "opponent_points": matchup["opponent_points"],
+                    }
+                )
+
+        except Exception as e:
+            print(f"Warning: Could not fetch data for year {year}: {e}")
+            continue
+
+    return all_matchups

--- a/src/gmb/taylor_eras.py
+++ b/src/gmb/taylor_eras.py
@@ -159,9 +159,15 @@ def calculate_era_win_percentages(historical_matchups: list[dict[str, Any]]) -> 
     for game in historical_matchups:
         game_date = get_week_date(game["year"], game["week"])
         game["era"] = get_era_for_date(game_date)
-        game["win"] = 1 if game["points"] > game["opponent_points"] else 0
-        game["loss"] = 1 if game["points"] < game["opponent_points"] else 0
-
+        if game["points"] > game["opponent_points"]:
+            game["win"] = 1
+            game["loss"] = 0
+        elif game["points"] < game["opponent_points"]:
+            game["win"] = 0
+            game["loss"] = 1
+        else:
+            game["win"] = 0.5
+            game["loss"] = 0.5
     df = pd.DataFrame(historical_matchups)
 
     # Group by owner and era to calculate aggregated stats


### PR DESCRIPTION
Features:
- Add Taylor Eras tab with game-by-game era assignment
- Display win percentage heatmap by Taylor Swift album eras
- Show era release dates on visualizations
- Identify most dominant owner-era combinations

Improvements:
- Fix owner name case sensitivity issues (normalize to title case)
- Add support for pre-2018 ESPN API (leagueHistory endpoint)
- Fix Plotly update_xaxis typo (should be update_xaxes)
- Remove redundant League Average Win % chart
- Add clarification about Taylor's Version re-recordings

Technical:
- Add taylor_eras.py module with TypedDict for type safety
- Fetch individual matchup data instead of season totals
- Sort eras chronologically in visualizations
- Update documentation with new features
- All tests passing, code formatted and linted